### PR TITLE
Attach footer to bottom

### DIFF
--- a/stylesheets/styles.scss
+++ b/stylesheets/styles.scss
@@ -23,9 +23,15 @@ $blockquote-font-size: $font-size-base;
  * Globals
  */
 
+html {
+  position: relative;
+  min-height: 100%;
+}
+
 body {
   padding-top: 50px;
   word-wrap: break-word;
+  padding-bottom: 60px;
 }
 
 img {
@@ -136,6 +142,9 @@ h6, .h6 {
   text-align: center;
   background-color: $dark-brown;
   border-top: 1px solid #e5e5e5;
+  position: absolute;
+  bottom: 0;
+  width: 100%;
 }
 
 .footer p:last-child {
@@ -145,6 +154,7 @@ h6, .h6 {
 /*
  * Team page
  */
+
 .teammember {
   margin-bottom: 2em;
   min-height: 180px;


### PR DESCRIPTION
Une légère amélioration pour éviter d'avoir une sorte de bande blanche en bas de page lorsque la hauteur du contenu n'est pas assez grande sur un écran large (1920px). Ca se produit pour les pages http://lescastcodeurs.com/concept/ et http://lescastcodeurs.com/parler/ :

![lcc-screenshot1](https://cloud.githubusercontent.com/assets/7253680/4021727/bce73d7a-2b01-11e4-9ba5-3c3799a33015.jpg)

Le fait de "fixer" le footer au bas de la page corrige ce problème.
