### PR TITLE
Amélioration de la navigation

### DIFF
--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -1,12 +1,12 @@
 <nav aria-label="Pagination">
-  <ul class="pagination justify-content-center">
+  <ul class="pagination justify-content-center lead">
     {%- if paginator.previous_page -%}
     <li class="page-item">
-      <a href="{{ paginator.previous_page_path | relative_url }}" class="page-link">&laquo; Précédent</a>
+      <a href="{{ paginator.previous_page_path | relative_url }}" class="page-link">&laquo;</a>
     </li>
     {%- else -%}
     <li class="page-item disabled">
-      <span class="page-link">&laquo; Précédent</span>
+      <span class="page-link">&laquo;</span>
     </li>
     {%- endif -%}
 
@@ -37,11 +37,11 @@
     {%- endfor -%}
     {%- if paginator.next_page -%}
     <li class="page-item">
-      <a href="{{ paginator.next_page_path | relative_url }}" class="page-link">Suivant &raquo;</a>
+      <a href="{{ paginator.next_page_path | relative_url }}" class="page-link">&raquo;</a>
     </li>
     {%- else -%}
     <li class="page-item disabled">
-      <span class="page-link">Suivant &raquo;</span>
+      <span class="page-link">&raquo;</span>
     </li>
     {%- endif -%}
   </ul>

--- a/_includes/post-navigation.html
+++ b/_includes/post-navigation.html
@@ -1,13 +1,17 @@
-<ul class="nav post-nav">
-  <li class="nav-item rounded-lg mr-auto">
-    {% if page.previous.url %}
-    <a href="{{ page.previous.url }}" class="btn btn-outline-primary">&laquo; {{ page.previous.title | truncate: 25 }}</a>
-    {% endif %}
-  </li>
+<div class="post-nav row">
+  {% if page.previous.url %}
+  <div class="col-6">
+    <a href="{{ page.previous.url }}" class="btn btn-outline-primary">
+      <span class="lead">&laquo;</span> {{ page.previous.title }}
+    </a>
+  </div>
+  {% endif %}
 
-  <li class="nav-item rounded-lg">
-    {% if page.next.url %}
-    <a href="{{ page.next.url }}" class="btn btn-outline-primary">{{ page.next.title | truncate: 25 }} &raquo;</a>
-    {% endif %}
-  </li>
-</ul>
+  {% if page.next.url %}
+  <div class="col-6 text-right">
+    <a href="{{ page.next.url }}" class="btn btn-outline-primary">
+      {{ page.next.title }} <span class="lead">&raquo;</span>
+    </a>
+  </div>
+  {% endif %}
+</div>

--- a/_includes/post-small-navigation.html
+++ b/_includes/post-small-navigation.html
@@ -1,0 +1,17 @@
+<div class="post-nav row">
+  {% if page.previous.url %}
+  <div class="col-6">
+    <a href="{{ page.previous.url }}" class="btn btn-outline-primary" title="{{ page.previous.title }}">
+      <span class="lead">&laquo;</span> Précédent
+    </a>
+  </div>
+  {% endif %}
+
+  {% if page.next.url %}
+  <div class="col-6 text-right">
+    <a href="{{ page.next.url }}" class="btn btn-outline-primary" title="{{ page.next.title }}">
+      Suivant <span class="lead">&raquo;</span>
+    </a>
+  </div>
+  {% endif %}
+</div>

--- a/_layouts/blog-post.html
+++ b/_layouts/blog-post.html
@@ -1,7 +1,8 @@
 ---
 layout: default
 ---
-{%- include post-navigation.html -%}
+
+{%- include post-small-navigation.html -%}
 
 <hr>
 
@@ -25,3 +26,9 @@ layout: default
 
   <a class="u-url" href="{{ page.url | relative_url }}" hidden></a>
 </article>
+
+<hr>
+
+{%- include post-navigation.html -%}
+
+<hr>


### PR DESCRIPTION
Les textes 'Précédent' / 'Suivant' on été supprimés de la pagination. Ils étaient trop grand pour la navigation sur mobile et cassaient la mise en page (apparition d'une scrollbar horizontale).

La barre de navigation en haut des articles qui permet de passer à l'article précédent / suivant à été revue :
- Les titres tronqués ont été remplacés par 'Précédent' / 'Suivant'. Un title a été ajouté sur les liens pour qu'on puisse quand même voir le titre de l'article au survol.
- Une navigation avec cette fois-ci le titre complet des articles a été ajoutée en fin d'article.