### PR TITLE
Correction du script de build

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -6,7 +6,7 @@ bundle install
 bundle exec jekyll clean
 bundle exec jekyll build
 
-while [[ $# -gt 0 ]]
+while [ $# -gt 0 ]
 do
   param="$1"
   case $param in


### PR DESCRIPTION
La syntaxe '[[ test ]]' est une syntaxe compatible bash, pas sh. Comme on utilise /bin/sh le script risque de ne pas fonctionner si /bin/sh n'est pas un lien symbolique vers /bin/bash. Pour le test qui était fait la syntaxe POSIX sh suffit.