### PR TITLE
Mise à jour de Jekyll en 4.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "jekyll", "~> 4.1"
+gem "jekyll", "~> 4.2"
 
 # Jekyll plugins
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
     ffi (1.15.0)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
-    i18n (1.8.9)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jekyll (4.2.0)
       addressable (~> 2.4)
@@ -43,7 +43,7 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
-    listen (3.4.1)
+    listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
@@ -68,7 +68,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  jekyll (~> 4.1)
+  jekyll (~> 4.2)
   jekyll-paginate (~> 1.1)
   jekyll-seo-tag (~> 2.1)
   jekyll-sitemap (~> 1.4)


### PR DESCRIPTION
Il n'y a aucune modification sur le site généré par rapport à la 4.1.0, à part la date de génération du site dans le flux Atom (ce qui est normal).

À noter qu'avec cette version les URLs construites avec site.url pointeront maintenant vers https://lescastcodeurs.com et non plus localhost en développement (jekyll serve). En effet Jekyll ne surcharge plus cette variable (cf. https://jekyllrb.com/news/2020/12/14/jekyll-4-2-0-released/). Cela n'impacte à priori que l'identifiant du flux Atom :
> $ ack site.url
> feed-intern.atom
> 13:  <id>{{ site.url | absolute_url | xml_escape }}</id>

Les release notes de Jekyll 4.2.0 sont disponibles sur https://jekyllrb.com/docs/history/#v4-2-0.