### PR TITLE
Ajout d'un workflow GitHub Actions de déploiement

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy site
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      DEPLOY_USER: ${{secrets.DEPLOY_USER}}
+      DEPLOY_HOST: ${{secrets.DEPLOY_HOST}}
+      DEPLOY_KEY: ${{secrets.DEPLOY_KEY}}
+      DEPLOY_TARGET: ${{secrets.DEPLOY_TARGET}}
+    steps:
+      - name: Checkout site
+        uses: actions/checkout@v2
+
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+          bundler-cache: true
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan "$DEPLOY_HOST" >> ~/.ssh/known_hosts
+          echo "$DEPLOY_KEY" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+
+      - name: Build site
+        run: bin/build
+
+      - name: Deploy site
+        run: bin/deploy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,9 +68,23 @@ Le site est alors disponible dans le répertoire `_site`.
 
 ### Publier le site
 
-Uniquement Emmanuel peut publier le site
+La publication du site passe par l'exécution du workflow GitHub Actions `deploy`. Ce workflow décompose globalement de la manière suivante :
+1. Préparation de l'environnement (ruby, configuration SSH nécessaire pour le rsync)
+2. Construction du site à l'aide de bin/build
+3. Déploiement du site à l'aide de bin/deploy (rsync)
 
-    ./bin/build --publish
+Pour fonctionner ce workflow GitHub Actions nécessite la déclaration des secrets suivants :
+- `DEPLOY_USER` : utilisateur SSH à utiliser pour la publication du site,
+- `DEPLOY_HOST` : serveur sur lequel le site doit être publié,
+- `DEPLOY_KEY` : clé SSH privée utilisée pour la connexion au serveur,
+- `DEPLOY_TARGET` : répertoire cible sur le serveur où les fichier du site seront copiés.
+
+Il est aussi possible de lancer manuellement la publication du site :
+
+    ./bin/build && ./bin/deploy
+
+Le script `bin/deploy` utilise les variables `DEPLOY_*` si elles sont définies. Si elles ne le sont pas des valeurs par défaut sont utilisées (cf.
+[bin/deploy](/bin/deploy)).
 
 ### Mise à jour de Jekyll et de ses dépendances
 
@@ -197,7 +211,6 @@ L'index de recherche est créé grâce au template [search.json](search.json) :
 
 ## Todo
 
-- install site build script on server + github push notif (cgi)
 - keep video directory
 - trouver un moyen de traduire les titres des pages "paginées" (pas faisable avec jekyll-paginate ?)
 - trouver une liste de termes à [exclure](https://github.com/christian-fei/Simple-Jekyll-Search/wiki#exclude-array-optional) pour tenter d'améliorer la

--- a/bin/build
+++ b/bin/build
@@ -5,16 +5,3 @@ set -e
 bundle install
 bundle exec jekyll clean
 JEKYLL_ENV=production bundle exec jekyll build
-
-while [ $# -gt 0 ]
-do
-  param="$1"
-  case $param in
-    -p|--publish)
-    # publish the website
-    shift # shift to next argument
-    rsync -avz --delete --filter="- /video/" --filter="- /cgi-bin/" _site/ lcc-web:/var/www/lescastcodeurs
-    ;;
-  esac
-done
-exit 0;

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+user="${DEPLOY_USER:-$(whoami)}"
+host="${DEPLOY_HOST:-lcc-web}"
+target="${DEPLOY_TARGET:-/var/www/lescastcodeurs}"
+src="_site/"
+dest="${user}@${host}:${target}"
+
+echo "Syncing $src to $dest"
+rsync -avz --delete --filter='- /video/' --filter='- /cgi-bin/' "$src" "$dest"


### PR DESCRIPTION
Ce workflow ne s'applique que sur la branche main et nécessite une configuration préablable (cf. la documentation "Publier le site").

bin/deploy est un nouveau script qui reprend ce qui était fait dans bin/build jusqu'à présent lorsque l'option --publish était activée, c'est à dire une synchronisation du site sur un serveur à l'aide de rsync.

Le workflow n'est pas basé sur jekyll/builder (https://github.com/actions/starter-workflows/blob/804289e1b5bf70f30e27dfe2c8c691c8cddd384a/ci/jekyll.yml) afin de rester au plus proche de ce qui était fait jusqu'à présent (utilisation du script bin/build). Un test a été fait avec jekyll/builder est il est à noter qu'au final ce workflow est plus souple et s'exécute plus rapidement une fois les gems mises en cache.