### PR TITLE
Amélioration du rendu du menu sur les petits écrans

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,5 @@
 <header id="site-header">
-  <nav id="site-nav" class="navbar navbar-expand-md navbar-dark bg-dark" role="navigation">
+  <nav id="site-nav" class="navbar navbar-expand-lg navbar-dark bg-dark" role="navigation">
     <div class="container">
       <a class="navbar-brand" href="{{ '/' | relative_url }}">{{ site.title | escape }}</a>
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -73,6 +73,18 @@ iframe {
 // Specific
 //
 
+// Permet d'avoir un meilleur rendu sur de très petits écrans
+#site-header {
+  .navbar-brand {
+    margin-right: 0;
+  }
+
+  .navbar-toggler {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
 #site-nav, #site-footer {
   color: $header-color !important;
   background-color: $header-background-color !important;


### PR DESCRIPTION
- Le togglers de la navbar s'affiche désormais plus tôt, empêchant ainsi les libellés de passer sur deux lignes.
- Sur les très petits écrans (320x480) le toggler n'était pas sur la même ligne que le nom du site. En supprimant quelques margins / paddings on améliore cela sans effets négatif autre que de réduire la largeur cliquable du toggler.